### PR TITLE
Add CocoIndex - ETL to build Knowledge Graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Knowledge Graph ETL (Extract, Transform, Load) refers to the process of extracti
 
 - [TrustGraph](https://github.com/trustgraph-ai/trustgraph) ![Status](https://img.shields.io/badge/status-active-brightgreen) ![Language](https://img.shields.io/badge/language-Python-blue) - Bulk ingestion of PDFs, TXT, or MD files built directly to RDF graphs with mapped vector embeddings.
 
-- [CocoIndex](https://github.com/cocoindex-io/cocoindex) ![Status](https://img.shields.io/badge/status-active-brightgreen) ![Language](https://img.shields.io/badge/language-Python-blue) - ETL to build real-time Knowledge Graph with incremental processing, support custom logic 
+- [CocoIndex](https://github.com/cocoindex-io/cocoindex) ![Status](https://img.shields.io/badge/status-active-brightgreen) ![Language](https://img.shields.io/badge/language-Python-blue) - ETL to build real-time Knowledge Graph with incremental processing, support custom logic.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Knowledge Graph ETL (Extract, Transform, Load) refers to the process of extracti
 
 - [TrustGraph](https://github.com/trustgraph-ai/trustgraph) ![Status](https://img.shields.io/badge/status-active-brightgreen) ![Language](https://img.shields.io/badge/language-Python-blue) - Bulk ingestion of PDFs, TXT, or MD files built directly to RDF graphs with mapped vector embeddings.
 
+- [CocoIndex](https://github.com/cocoindex-io/cocoindex) ![Status](https://img.shields.io/badge/status-active-brightgreen) ![Language](https://img.shields.io/badge/language-Python-blue) - ETL to build real-time Knowledge Graph with incremental processing, support custom logic 
 
 ---
 


### PR DESCRIPTION
CocoIndex: https://github.com/cocoindex-io/cocoindex
Documentation: 
- We support property graph targets: https://cocoindex.io/docs/ops/storages#property-graph-targets
- RDF is on the way: https://github.com/cocoindex-io/cocoindex/issues/416

example usage: https://cocoindex.io/blogs/knowledge-graph-for-docs
